### PR TITLE
fix: bug of Decorator `Enum`: the `definition` passed in the function argument is not used, but only {enum: enumKeys} is returned.

### DIFF
--- a/lib/core/meta/field/common/enum.ts
+++ b/lib/core/meta/field/common/enum.ts
@@ -11,10 +11,11 @@ export function Enum(enumKeys: Array<string>, definition: Partial<PropertyDefini
         (targetPrototype: Object, propertyName: string) => {
             let type: any = InferType(targetPrototype, propertyName)
             type = (type && type.name == 'Array') ? [Schema.Types.String] : Schema.Types.String;
+            Object.assign(definition, { enum: enumKeys })
 
             return {
                 type,
-                definition:  { enum: enumKeys, }
+                definition
             }
         }
     );


### PR DESCRIPTION
  In [enum.ts#L17](https://github.com/OfirTheOne/mongo-ts/blob/master/lib/core/meta/field/common/enum.ts#L17)
https://github.com/OfirTheOne/mongo-ts/blob/0325b768a97e855c2feefd188e695ccefa788824/lib/core/meta/field/common/enum.ts#L8-L20
The `definition` field contained in the returned object contains only `{enum: enumKeys}`, but the value in the `defination` function argument is not used.

  That causes the following example code in the [README.md](https://github.com/OfirTheOne/mongo-ts/blob/master/README.md) cannot work properly:

```js
// helper, take enum type and return his keys as an array.
const enumKeys = (eType => (Object.values(eType).filter(e => typeof e == 'string')));
 
enum Permission { 'delete' ,'update', 'insert' }
 
class User ... {
    @Enum(enumKeys(Permission), { default: ['insert'] }); 
        permissions: Permission[];
    ...
}
```
which should be mapped to
```js
User = {
    permissions: {
        type: [Schema.Types.String],
        enum: ['delete' ,'update', 'insert'],
        default: ['insert']
    }
    ...
}
```
but actually mapped to
```js
User = {
    permissions: {
        type: [Schema.Types.String],
        enum: ['delete' ,'update', 'insert'],
        // the `default` field is missing
    }
    ...
}
```

  Thank you for your time reading this and thank you for your work in this project! It really helps me!